### PR TITLE
fix nested blockquote formatting

### DIFF
--- a/pages/docs/mix-tasks.md
+++ b/pages/docs/mix-tasks.md
@@ -127,13 +127,13 @@ the server by typing commands. Available commands are:
     You can also send EOF to stop the server, by pressing <kbd>Ctrl</kbd> +
     <kbd>D</kbd> on UNIX-based systems.
 
-    > Note
-    > {: .title }
-    >
-    > Please make sure you type the `quit` command to stop the development
-    > server. Pressing <kbd>Ctrl</kbd> + <kbd>C</kbd> causes unclean exit,
-    > leaving the temporary directory not removed.
-    {: .note }
+  > Note
+  > {: .title }
+  >
+  > Please make sure you type the `quit` command to stop the development
+  > server. Pressing <kbd>Ctrl</kbd> + <kbd>C</kbd> causes unclean exit,
+  > leaving the temporary directory not removed.
+  {: .note }
 
 - - -
 

--- a/pages/docs/mix-tasks.md
+++ b/pages/docs/mix-tasks.md
@@ -133,7 +133,7 @@ the server by typing commands. Available commands are:
   > Please make sure you type the `quit` command to stop the development
   > server. Pressing <kbd>Ctrl</kbd> + <kbd>C</kbd> causes unclean exit,
   > leaving the temporary directory not removed.
-  {: .note }
+    {: .note }
 
 - - -
 


### PR DESCRIPTION
Earmark has an [issue](https://github.com/pragdave/earmark/issues/298) where blockquotes nested in lists only work with an indentation of 2 spaces.

As it is, 4 spaces produces this:

![Annotation 2019-10-20 192209](https://user-images.githubusercontent.com/7574985/67172149-05753e80-f36f-11e9-99c4-95c2552473e6.png)
