### PR TITLE
Add a missing enclosing tag(`<%= %>`)

### DIFF
--- a/pages/docs/templates.md
+++ b/pages/docs/templates.md
@@ -117,7 +117,7 @@ customize its values by editing the
 <!-- Usage in EEx -->
 <ul>
   <%= for page <- @all_pages, page.group === "main-menu" do %>
-    <li><a href="page.url" title="<%= page.title %>"><%= page.label %></a></li>
+    <li><a href="<%= page.url %>" title="<%= page.title %>"><%= page.label %></a></li>
   <% end %>
 </ul>
 ```


### PR DESCRIPTION
In [Templates - Serum](https://dalgona.github.io/Serum/docs/templates.html#@all_pages---list-of-all-pages), `href` property of `a` tag should be enclosed with `<%= %>`.